### PR TITLE
Fix Mac build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,11 @@
-cmake_minimum_required (VERSION 3.7.2 FATAL_ERROR)
+cmake_minimum_required (VERSION 3.8 FATAL_ERROR)
 
 find_program (CLANG_TIDY_EXE NAMES "clang-tidy")
 if (CLANG_TIDY_EXE)
   set (CMAKE_CXX_CLANG_TIDY clang-tidy)
 endif ()
+
+set (CMAKE_CXX_STANDARD 17)
 
 project (panwave)
 
@@ -19,7 +21,6 @@ set (TEST_SOURCES ${PROJECT_SOURCE_DIR}/test/test.cc)
 add_executable (panwave_test ${TEST_SOURCES})
 target_link_libraries (panwave_test panwave)
 
-set (CMAKE_CXX_STANDARD 17)
 if (MSVC)
   # disable some benign warnings on MSVC
   add_compile_options ("/Wall;/wd4514;/wd4625;/wd4626;/wd5026;/wd5027;/wd5045;/wd4710;/wd4820;")


### PR DESCRIPTION
The CMAKE_CXX_STANDARD variable needs to be set before targets are defined. It seems to work on other platforms when this is done out of order but it doesn't work on Mac.